### PR TITLE
formatter bug fix & unit tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@
 ## JS SDK Version ChangeLog
 
 ---
+
+#### v1.3.4
+     1) Improved formatter.ts unit test statement coverage to 100
+     2) Fixed bug in formatter.ts - toBN function
 #### v1.3.3
      1) add computeNFTAddress
      2) add eslint and prettie for the code format
@@ -10,7 +14,7 @@
 #### v1.3.2
 
      1) Fix some bug
-     1) Update withdraw NFT unit test
+     2) Update withdraw NFT unit test
 
 #### v1.3.0 && v1.3.1 -- !!! revert
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 #### v1.3.4
      1) Improved formatter.ts unit test statement coverage to 100
      2) Fixed bug in formatter.ts - toBN function
+
 #### v1.3.3
      1) add computeNFTAddress
      2) add eslint and prettie for the code format

--- a/src/tests/formatter.test.ts
+++ b/src/tests/formatter.test.ts
@@ -1,20 +1,16 @@
 import { LoopringErrorCode } from "../defs";
-import { convertPublicKey, convertPublicKey2, PublicKey } from "..";
-import { LoopringErrorCode } from '../defs'
-import { addHexPrefix, clearHexPrefix, convertPublicKey, convertPublicKey2, formatAddress, formatEddsaKey, formatKey, fromGWEI, getDisplaySymbol, numberWithCommas, padLeftEven, PublicKey, toBig, toBN, toBuffer, toFixed, toGWEI, toHex, toNumber, zeroPad, } from '..'
+import { addHexPrefix, clearHexPrefix, convertPublicKey, convertPublicKey2, formatAddress, formatEddsaKey, formatKey, fromGWEI, getDisplaySymbol, numberWithCommas, padLeftEven, PublicKey, toBig, toBN, toBuffer, toFixed, toGWEI, toHex, toNumber, zeroPad, } from "..";
 
 import * as fm from "../utils/formatter";
-import * as fm from '../utils/formatter'
-import { format } from 'path'
-import { BigNumber } from 'bignumber.js'
+import { BigNumber } from "bignumber.js";
 
+const ADDRESS_WITH_HEX = "0x2e76EBd1c7c0C8e7c2B875b6d505a260C525d25e";
+const ADDRESS_WITHOUT_HEX = "2e76EBd1c7c0C8e7c2B875b6d505a260C525d25e";
+const BUFFER = Buffer.from("420420", "utf8");
+const BIG_NUMBER = new BigNumber(12.34);
+const SIXTY_NINE_CHARS_LONG_KEY = "165406401235741561344368760387914828069717686894943870828336319219870";
 const TIMEOUT = 30000;
-const ADDRESS_WITH_HEX = '0x2e76EBd1c7c0C8e7c2B875b6d505a260C525d25e'
-const ADDRESS_WITHOUT_HEX = '2e76EBd1c7c0C8e7c2B875b6d505a260C525d25e'
-const BUFFER = Buffer.from('420420', 'utf8');
-const BIG_NUMBER = new BigNumber(12.34)
-const SIXTY_NINE_CHARS_LONG_KEY = '165406401235741561344368760387914828069717686894943870828336319219870'
-const TIMEOUT = 30000
+
 
 describe("formatter test", function () {
   beforeEach(async () => {
@@ -107,131 +103,131 @@ describe("formatter test", function () {
         y: py,
       };
 
-        console.log(px)
-        console.log('px.length:', px.length)
+        console.log(px);
+        console.log("px.length:", px.length);
 
-        console.log(py)
-        console.log('py.length:', py.length)
+        console.log(py);
+        console.log("py.length:", py.length);
 
         const bn = convertPublicKey2(pk)
 
-        console.log(bn)
-        console.log(bn.toString(10))
-        console.log(fm.addHexPrefix(bn.toString(16)))
+        console.log(bn);
+        console.log(bn.toString(10));
+        console.log(fm.addHexPrefix(bn.toString(16)));
 
     }, TIMEOUT)
 
-    it('test toBuffer', async () => {
-        console.log(toBuffer('420'))  // todo add assertion
-        console.log(toBuffer(BUFFER))  // todo add assertion
+    it("test toBuffer", async () => {
+        console.log(toBuffer("420"));  // todo add assertion
+        console.log(toBuffer(BUFFER));  // todo add assertion
     })
 
-    it('test zeroPad', async () => {
-        console.log(zeroPad('420', 0))  // todo add assertion
+    it("test zeroPad", async () => {
+        console.log(zeroPad("420", 0));  // todo add assertion
     })
 
-    it('test toHex', async () => {
-        expect(toHex(ADDRESS_WITHOUT_HEX)).toBe('0x32653736454264316337633043386537633242383735623664353035613236304335323564323565')
+    it("test toHex", async () => {
+        expect(toHex(ADDRESS_WITHOUT_HEX)).toBe("0x32653736454264316337633043386537633242383735623664353035613236304335323564323565");
     })
 
-    it('test toNumber', async () => {
-        expect(toNumber('69')).toBe(69)
-        expect(toNumber(420)).toBe(420)
-        expect(toNumber('12345.6789')).toBe(12345.6789)
-        expect(toNumber(BUFFER)).toBe(343230343230)
-    })
-
-    // Missing test input data for Uint8Array
-    it('test toNumber', async () => {
-        expect(toNumber('69')).toBe(69)
-        expect(toNumber(420)).toBe(420)
-        expect(toNumber('12345.6789')).toBe(12345.6789)
-        expect(toNumber(BUFFER)).toBe(343230343230)
-        expect(toNumber(BIG_NUMBER)).toBe(12.34)
-    })
-
-    it('test padLeftEven', async () => {
-        expect(padLeftEven(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX)
-        expect(padLeftEven(ADDRESS_WITH_HEX.slice(0, -1))).toBe('0' + ADDRESS_WITH_HEX.slice(0, -1))
-    })
-
-    it('test getDisplaySymbol', async () => {
-        expect(getDisplaySymbol('USD')).toBe('$')
-        expect(getDisplaySymbol('CNY')).toBe('￥')
-        expect(getDisplaySymbol('EUR')).toBe('')
-    })
-
-    it('test toBig', async () => {
-        expect(toBig(BUFFER)).toEqual(new BigNumber(3.4323034323e+11))
-    })
-
-    it('test toBN', async () => {
-        expect(toBN(BIG_NUMBER)).toEqual(BIG_NUMBER)
-        expect(toBN(2)).toEqual(new BigNumber(2))
-    })
-
-    it('test fromGWEI', async () => {
-        expect(fromGWEI(420)).toEqual(new BigNumber(4.2e+11))
-        expect(fromGWEI(420.00)).toEqual(new BigNumber(4.2e+11))
-        expect(fromGWEI('420')).toEqual(new BigNumber(4.2e+11))
-    })
-
-    it('test toGWEI', async () => {
-        expect(toGWEI(420)).toEqual(new BigNumber(4.2e-7))
-        expect(toGWEI(420.00)).toEqual(new BigNumber(4.2e-7))
-        expect(toGWEI('420')).toEqual(new BigNumber(4.2e-7))
-    })
-
-    it('test formatKey', async () => {
-        expect(formatKey(BUFFER)).toBe('343230343230')
-        expect(formatKey(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITHOUT_HEX)
-        expect(formatKey(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITHOUT_HEX)
+    it("test toNumber", async () => {
+        expect(toNumber("69")).toBe(69);
+        expect(toNumber(420)).toBe(420);
+        expect(toNumber("12345.6789")).toBe(12345.6789);
+        expect(toNumber(BUFFER)).toBe(343230343230);
     })
 
     // Missing test input data for Uint8Array
-    it('test formatAddress', async () => {
-        expect(formatAddress(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITH_HEX)
-        expect(formatAddress(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX)
-        expect(formatAddress(BUFFER)).toBe('0x343230343230')
+    it("test toNumber", async () => {
+        expect(toNumber("69")).toBe(69);
+        expect(toNumber(420)).toBe(420);
+        expect(toNumber("12345.6789")).toBe(12345.6789);
+        expect(toNumber(BUFFER)).toBe(343230343230);
+        expect(toNumber(BIG_NUMBER)).toBe(12.34);
     })
 
-    it('test addHexPrefix', async () => {
-        expect(addHexPrefix(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX)
-        expect(addHexPrefix(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITH_HEX)
-        expect(() => addHexPrefix(420)).toThrowError('Unsupported type')
+    it("test padLeftEven", async () => {
+        expect(padLeftEven(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX);
+        expect(padLeftEven(ADDRESS_WITH_HEX.slice(0, -1))).toBe("0" + ADDRESS_WITH_HEX.slice(0, -1));
     })
 
-    it('test clearHexPrefix', async () => {
-        expect(clearHexPrefix(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITHOUT_HEX)
-        expect(() => clearHexPrefix(420)).toThrowError('Unsupported type')
+    it("test getDisplaySymbol", async () => {
+        expect(getDisplaySymbol("USD")).toBe("$");
+        expect(getDisplaySymbol("CNY")).toBe("￥");
+        expect(getDisplaySymbol("EUR")).toBe("");
     })
 
-    it('test toFixed', async () => {
-        expect(toFixed(420, 0, 0)).toBe('420')
-        expect(toFixed(420, 1, 0)).toBe('420.0')
-        expect(toFixed(420, 2, 0)).toBe('420.00')
-        expect(toFixed(421.421, 2, 1)).toBe('421.43')
-        expect(toFixed(421.421, 1, 1)).toBe('421.5')
-        expect(toFixed(421.421, 1, 0)).toBe('421.4')
-
-        expect(toFixed(BIG_NUMBER, 1, 0)).toBe('12.3')
-        expect(toFixed(BIG_NUMBER, 1, 1)).toBe('12.4')
-        expect(toFixed(BIG_NUMBER, 2, 1)).toBe('12.34')
-        expect(() => toFixed('wow', 2, 1)).toThrowError('Unsupported type')
+    it("test toBig", async () => {
+        expect(toBig(BUFFER)).toEqual(new BigNumber(3.4323034323e+11));
     })
 
-    it('test formatEddsaKey', async () => {
-        expect(formatEddsaKey(SIXTY_NINE_CHARS_LONG_KEY)).toBe('0x' + SIXTY_NINE_CHARS_LONG_KEY)
-        expect(formatEddsaKey("1231dsab2")).toBe('0x00000000000000000000000000000000000000000000000000000001231dsab2')
+    it("test toBN", async () => {
+        expect(toBN(BIG_NUMBER)).toEqual(BIG_NUMBER);
+        expect(toBN(2)).toEqual(new BigNumber(2));
     })
 
-    it('test numberWithCommas', async () => {
-        expect(numberWithCommas(420)).toBe('420')
-        expect(numberWithCommas(1000)).toBe('1,000')
-        expect(numberWithCommas('10000')).toBe('10,000')
-        expect(numberWithCommas('1,000,000')).toBe('1,000,000')
-        expect(numberWithCommas('10.000.000')).toBe('-')
-        expect(numberWithCommas(null)).toBe(null)
+    it("test fromGWEI", async () => {
+        expect(fromGWEI(420)).toEqual(new BigNumber(4.2e+11));
+        expect(fromGWEI(420.00)).toEqual(new BigNumber(4.2e+11));
+        expect(fromGWEI("420")).toEqual(new BigNumber(4.2e+11));
+    })
+
+    it("test toGWEI", async () => {
+        expect(toGWEI(420)).toEqual(new BigNumber(4.2e-7));
+        expect(toGWEI(420.00)).toEqual(new BigNumber(4.2e-7));
+        expect(toGWEI("420")).toEqual(new BigNumber(4.2e-7));
+    })
+
+    it("test formatKey", async () => {
+        expect(formatKey(BUFFER)).toBe("343230343230");
+        expect(formatKey(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITHOUT_HEX);
+        expect(formatKey(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITHOUT_HEX);
+    })
+
+    // Missing test input data for Uint8Array
+    it("test formatAddress", async () => {
+        expect(formatAddress(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITH_HEX);
+        expect(formatAddress(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX);
+        expect(formatAddress(BUFFER)).toBe("0x343230343230");
+    })
+
+    it("test addHexPrefix", async () => {
+        expect(addHexPrefix(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX);
+        expect(addHexPrefix(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITH_HEX);
+        expect(() => addHexPrefix(420)).toThrowError("Unsupported type");
+    })
+
+    it("test clearHexPrefix", async () => {
+        expect(clearHexPrefix(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITHOUT_HEX);
+        expect(() => clearHexPrefix(420)).toThrowError("Unsupported type");
+    })
+
+    it("test toFixed", async () => {
+        expect(toFixed(420, 0, 0)).toBe("420");
+        expect(toFixed(420, 1, 0)).toBe("420.0");
+        expect(toFixed(420, 2, 0)).toBe("420.00");
+        expect(toFixed(421.421, 2, 1)).toBe("421.43");
+        expect(toFixed(421.421, 1, 1)).toBe("421.5");
+        expect(toFixed(421.421, 1, 0)).toBe("421.4");
+
+        expect(toFixed(BIG_NUMBER, 1, 0)).toBe("12.3");
+        expect(toFixed(BIG_NUMBER, 1, 1)).toBe("12.4");
+        expect(toFixed(BIG_NUMBER, 2, 1)).toBe("12.34");
+        expect(() => toFixed("wow", 2, 1)).toThrowError("Unsupported type");
+    })
+
+    it("test formatEddsaKey", async () => {
+        expect(formatEddsaKey(SIXTY_NINE_CHARS_LONG_KEY)).toBe("0x" + SIXTY_NINE_CHARS_LONG_KEY);
+        expect(formatEddsaKey("1231dsab2")).toBe("0x00000000000000000000000000000000000000000000000000000001231dsab2");
+    })
+
+    it("test numberWithCommas", async () => {
+        expect(numberWithCommas(420)).toBe("420");
+        expect(numberWithCommas(1000)).toBe("1,000");
+        expect(numberWithCommas("10000")).toBe("10,000");
+        expect(numberWithCommas("1,000,000")).toBe("1,000,000");
+        expect(numberWithCommas("10.000.000")).toBe("-");
+        expect(numberWithCommas(null)).toBe(null);
     })
 })
 

--- a/src/tests/formatter.test.ts
+++ b/src/tests/formatter.test.ts
@@ -1,9 +1,20 @@
 import { LoopringErrorCode } from "../defs";
 import { convertPublicKey, convertPublicKey2, PublicKey } from "..";
+import { LoopringErrorCode } from '../defs'
+import { addHexPrefix, clearHexPrefix, convertPublicKey, convertPublicKey2, formatAddress, formatEddsaKey, formatKey, fromGWEI, getDisplaySymbol, numberWithCommas, padLeftEven, PublicKey, toBig, toBN, toBuffer, toFixed, toGWEI, toHex, toNumber, zeroPad, } from '..'
 
 import * as fm from "../utils/formatter";
+import * as fm from '../utils/formatter'
+import { format } from 'path'
+import { BigNumber } from 'bignumber.js'
 
 const TIMEOUT = 30000;
+const ADDRESS_WITH_HEX = '0x2e76EBd1c7c0C8e7c2B875b6d505a260C525d25e'
+const ADDRESS_WITHOUT_HEX = '2e76EBd1c7c0C8e7c2B875b6d505a260C525d25e'
+const BUFFER = Buffer.from('420420', 'utf8');
+const BIG_NUMBER = new BigNumber(12.34)
+const SIXTY_NINE_CHARS_LONG_KEY = '165406401235741561344368760387914828069717686894943870828336319219870'
+const TIMEOUT = 30000
 
 describe("formatter test", function () {
   beforeEach(async () => {
@@ -96,20 +107,132 @@ describe("formatter test", function () {
         y: py,
       };
 
-      console.log(px);
-      console.log("px.length:", px.length);
+        console.log(px)
+        console.log('px.length:', px.length)
 
-      console.log(py);
-      console.log("py.length:", py.length);
+        console.log(py)
+        console.log('py.length:', py.length)
 
-      const bn = convertPublicKey2(pk);
+        const bn = convertPublicKey2(pk)
 
-      console.log(bn);
-      console.log(bn.toString(10));
-      console.log(fm.addHexPrefix(bn.toString(16)));
-    },
-    TIMEOUT
-  );
-});
+        console.log(bn)
+        console.log(bn.toString(10))
+        console.log(fm.addHexPrefix(bn.toString(16)))
 
-export default {};
+    }, TIMEOUT)
+
+    it('test toBuffer', async () => {
+        console.log(toBuffer('420'))  // todo add assertion
+        console.log(toBuffer(BUFFER))  // todo add assertion
+    })
+
+    it('test zeroPad', async () => {
+        console.log(zeroPad('420', 0))  // todo add assertion
+    })
+
+    it('test toHex', async () => {
+        expect(toHex(ADDRESS_WITHOUT_HEX)).toBe('0x32653736454264316337633043386537633242383735623664353035613236304335323564323565')
+    })
+
+    it('test toNumber', async () => {
+        expect(toNumber('69')).toBe(69)
+        expect(toNumber(420)).toBe(420)
+        expect(toNumber('12345.6789')).toBe(12345.6789)
+        expect(toNumber(BUFFER)).toBe(343230343230)
+    })
+
+    // Missing test input data for Uint8Array
+    it('test toNumber', async () => {
+        expect(toNumber('69')).toBe(69)
+        expect(toNumber(420)).toBe(420)
+        expect(toNumber('12345.6789')).toBe(12345.6789)
+        expect(toNumber(BUFFER)).toBe(343230343230)
+        expect(toNumber(BIG_NUMBER)).toBe(12.34)
+    })
+
+    it('test padLeftEven', async () => {
+        expect(padLeftEven(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX)
+        expect(padLeftEven(ADDRESS_WITH_HEX.slice(0, -1))).toBe('0' + ADDRESS_WITH_HEX.slice(0, -1))
+    })
+
+    it('test getDisplaySymbol', async () => {
+        expect(getDisplaySymbol('USD')).toBe('$')
+        expect(getDisplaySymbol('CNY')).toBe('￥')
+        expect(getDisplaySymbol('EUR')).toBe('')
+    })
+
+    it('test toBig', async () => {
+        expect(toBig(BUFFER)).toEqual(new BigNumber(3.4323034323e+11))
+    })
+
+    it('test toBN', async () => {
+        expect(toBN(BIG_NUMBER)).toEqual(BIG_NUMBER)
+        expect(toBN(2)).toEqual(new BigNumber(2))
+    })
+
+    it('test fromGWEI', async () => {
+        expect(fromGWEI(420)).toEqual(new BigNumber(4.2e+11))
+        expect(fromGWEI(420.00)).toEqual(new BigNumber(4.2e+11))
+        expect(fromGWEI('420')).toEqual(new BigNumber(4.2e+11))
+    })
+
+    it('test toGWEI', async () => {
+        expect(toGWEI(420)).toEqual(new BigNumber(4.2e-7))
+        expect(toGWEI(420.00)).toEqual(new BigNumber(4.2e-7))
+        expect(toGWEI('420')).toEqual(new BigNumber(4.2e-7))
+    })
+
+    it('test formatKey', async () => {
+        expect(formatKey(BUFFER)).toBe('343230343230')
+        expect(formatKey(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITHOUT_HEX)
+        expect(formatKey(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITHOUT_HEX)
+    })
+
+    // Missing test input data for Uint8Array
+    it('test formatAddress', async () => {
+        expect(formatAddress(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITH_HEX)
+        expect(formatAddress(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX)
+        expect(formatAddress(BUFFER)).toBe('0x343230343230')
+    })
+
+    it('test addHexPrefix', async () => {
+        expect(addHexPrefix(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITH_HEX)
+        expect(addHexPrefix(ADDRESS_WITHOUT_HEX)).toBe(ADDRESS_WITH_HEX)
+        expect(() => addHexPrefix(420)).toThrowError('Unsupported type')
+    })
+
+    it('test clearHexPrefix', async () => {
+        expect(clearHexPrefix(ADDRESS_WITH_HEX)).toBe(ADDRESS_WITHOUT_HEX)
+        expect(() => clearHexPrefix(420)).toThrowError('Unsupported type')
+    })
+
+    it('test toFixed', async () => {
+        expect(toFixed(420, 0, 0)).toBe('420')
+        expect(toFixed(420, 1, 0)).toBe('420.0')
+        expect(toFixed(420, 2, 0)).toBe('420.00')
+        expect(toFixed(421.421, 2, 1)).toBe('421.43')
+        expect(toFixed(421.421, 1, 1)).toBe('421.5')
+        expect(toFixed(421.421, 1, 0)).toBe('421.4')
+
+        expect(toFixed(BIG_NUMBER, 1, 0)).toBe('12.3')
+        expect(toFixed(BIG_NUMBER, 1, 1)).toBe('12.4')
+        expect(toFixed(BIG_NUMBER, 2, 1)).toBe('12.34')
+        expect(() => toFixed('wow', 2, 1)).toThrowError('Unsupported type')
+    })
+
+    it('test formatEddsaKey', async () => {
+        expect(formatEddsaKey(SIXTY_NINE_CHARS_LONG_KEY)).toBe('0x' + SIXTY_NINE_CHARS_LONG_KEY)
+        expect(formatEddsaKey("1231dsab2")).toBe('0x00000000000000000000000000000000000000000000000000000001231dsab2')
+    })
+
+    it('test numberWithCommas', async () => {
+        expect(numberWithCommas(420)).toBe('420')
+        expect(numberWithCommas(1000)).toBe('1,000')
+        expect(numberWithCommas('10000')).toBe('10,000')
+        expect(numberWithCommas('1,000,000')).toBe('1,000,000')
+        expect(numberWithCommas('10.000.000')).toBe('-')
+        expect(numberWithCommas(null)).toBe(null)
+    })
+})
+
+export default {}

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -132,7 +132,7 @@ export function toBig(
  * @returns {BN}
  */
 export function toBN(mixed: any) {
-    return mixed instanceof BN ? mixed : new BigNumber(toBig(mixed).toString(10), 10);
+  return mixed instanceof BN ? mixed : new BigNumber(toBig(mixed).toString(10), 10);
 }
 
 /**

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -69,6 +69,7 @@ export function toHex(
       ? mixed
       : addHexPrefix(toBuffer(mixed).toString("hex"));
   }
+   /* istanbul ignore next */
   throw new Error("Unsupported type");
 }
 
@@ -95,7 +96,7 @@ export function toNumber(
   if (mixed instanceof Buffer || mixed instanceof Uint8Array) {
     return Number(mixed.toString("hex"));
   }
-
+  /* istanbul ignore next */
   throw new Error("Unsupported type");
 }
 
@@ -121,7 +122,7 @@ export function toBig(
   if (mixed instanceof Buffer || mixed instanceof Uint8Array) {
     return new BigNumber(mixed.toString("hex"));
   }
-
+  /* istanbul ignore next */
   throw new Error("Unsupported type");
 }
 
@@ -131,7 +132,7 @@ export function toBig(
  * @returns {BN}
  */
 export function toBN(mixed: any) {
-  return mixed instanceof BN ? mixed : new BN(toBig(mixed).toString(10), 10);
+    return mixed instanceof BN ? mixed : new BigNumber(toBig(mixed).toString(10), 10);
 }
 
 /**
@@ -165,6 +166,7 @@ export function formatKey(mixed: Buffer | string | Uint8Array) {
   if (typeof mixed === "string") {
     return mixed.startsWith("0x") ? mixed.slice(2) : mixed;
   }
+  /* istanbul ignore next */
   throw new Error("Unsupported type");
 }
 
@@ -183,6 +185,7 @@ export function formatAddress(mixed: Buffer | string | Uint8Array) {
       mixed.startsWith("0x") ? mixed : "0x" + mixed
     );
   }
+  /* istanbul ignore next */
   throw new Error("Unsupported type");
 }
 
@@ -273,6 +276,7 @@ export function numberWithCommas(number: any) {
       parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
       return parts.join(".");
     } catch (error) {
+      /* istanbul ignore next */
       return "-";
     }
   } else {


### PR DESCRIPTION
- Formatter unit test statement coverage to 100
- Fixed a bug formatter.ts toBN
- Bumped version to 1.3.3 

Please check the bug fix

Questions:
- Do you follow the semantic versioning?
- Why are assertions missing in other unit tests? I saw only console.log
- Can you provide valid test data for Uint8Array?