### PR TITLE
correct JS_SDK link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn add @loopring-web/loopring-sdk
 
 Please see the [documentation page](https://loopring.github.io/loopring_sdk/) for information about getting started and developing with the Loopring SDK.
 
-- [JS SDK](https://loopring.github.io/loopring_sdk)
+- [JS SDK](https://loopring.github.io/loopring_sdk/js_sdk/INTRO)
 - [Python](https://github.com/Loopring/hello_loopring)
 - [APIs](https://docs.loopring.io/en/)
 


### PR DESCRIPTION
the current JS_SDK link in the readme file links to the introduction page. should link to the correct JS_SDK docs page