### PR TITLE
Fix for failed mints on loopring.io

### DIFF
--- a/docs/js_sdk/NFTAction/metaNFT.md
+++ b/docs/js_sdk/NFTAction/metaNFT.md
@@ -46,9 +46,9 @@ console.log(
 ## ipfsCid0ToNftID
 
 ```ts
-const ipfs = "QmVYQaf5BP3y8Myr9m4z4FCZYx2v8NJmSHGzm2a2gqig9d";
+const ipfs = "QmNuqdeWUJ9iEiw5qZfJ2pJ9onqAS45ZffvV8JQSUzp7DQ";
 const nftID =
-  "0x6b04cd991b972198cc63115c8abc3bf4ed73f07353c44271e940841b466a66f8";
+  "0x0880847b7587968f32ba6c741f9d797d9dc64971979922a80c4e590453b8dc2f";
 console.log(
   `ipfsCid0ToNftID: ipfs: `,
   ipfs,
@@ -61,9 +61,9 @@ console.log(
 ## ipfsNftIDToCid
 
 ```ts
-const ipfs = "QmVYQaf5BP3y8Myr9m4z4FCZYx2v8NJmSHGzm2a2gqig9d";
+const ipfs = "QmNuqdeWUJ9iEiw5qZfJ2pJ9onqAS45ZffvV8JQSUzp7DQ";
 const nftID =
-  "0x6b04cd991b972198cc63115c8abc3bf4ed73f07353c44271e940841b466a66f8";
+  "0x0880847b7587968f32ba6c741f9d797d9dc64971979922a80c4e590453b8dc2f";
 
 console.log(
   `ipfsCid0ToNftID: nftID: `,

--- a/src/api/nft_api.ts
+++ b/src/api/nft_api.ts
@@ -285,7 +285,7 @@ export class NFTAPI extends BaseAPI {
     const cid = new CID(cidV0Str);
     const hashHex = Buffer.from(cid.multihash.slice(2)).toString("hex");
     const hashBN = new BN(hashHex, 16);
-    return "0x" + hashBN.toString("hex");
+    return "0x" + hashBN.toString("hex").padStart(64, "0");
   }
 
   /**

--- a/src/tests/demo/NFTAction/metaNFT.md
+++ b/src/tests/demo/NFTAction/metaNFT.md
@@ -46,9 +46,9 @@ console.log(
 ## ipfsCid0ToNftID
 
 ```ts
-const ipfs = "QmVYQaf5BP3y8Myr9m4z4FCZYx2v8NJmSHGzm2a2gqig9d";
+const ipfs = "QmNuqdeWUJ9iEiw5qZfJ2pJ9onqAS45ZffvV8JQSUzp7DQ";
 const nftID =
-  "0x6b04cd991b972198cc63115c8abc3bf4ed73f07353c44271e940841b466a66f8";
+  "0x0880847b7587968f32ba6c741f9d797d9dc64971979922a80c4e590453b8dc2f";
 console.log(
   `ipfsCid0ToNftID: ipfs: `,
   ipfs,
@@ -61,9 +61,9 @@ console.log(
 ## ipfsNftIDToCid
 
 ```ts
-const ipfs = "QmVYQaf5BP3y8Myr9m4z4FCZYx2v8NJmSHGzm2a2gqig9d";
+const ipfs = "QmNuqdeWUJ9iEiw5qZfJ2pJ9onqAS45ZffvV8JQSUzp7DQ";
 const nftID =
-  "0x6b04cd991b972198cc63115c8abc3bf4ed73f07353c44271e940841b466a66f8";
+  "0x0880847b7587968f32ba6c741f9d797d9dc64971979922a80c4e590453b8dc2f";
 
 console.log(
   `ipfsCid0ToNftID: nftID: `,

--- a/src/tests/demo/NFTAction/metaNFT.test.ts
+++ b/src/tests/demo/NFTAction/metaNFT.test.ts
@@ -42,9 +42,9 @@ describe("metaNFT", function () {
     );
   });
   it("ipfsCid0ToNftID", () => {
-    const ipfs = "QmVYQaf5BP3y8Myr9m4z4FCZYx2v8NJmSHGzm2a2gqig9d";
+    const ipfs = "QmNuqdeWUJ9iEiw5qZfJ2pJ9onqAS45ZffvV8JQSUzp7DQ";
     const nftID =
-      "0x6b04cd991b972198cc63115c8abc3bf4ed73f07353c44271e940841b466a66f8";
+      "0x0880847b7587968f32ba6c741f9d797d9dc64971979922a80c4e590453b8dc2f";
     console.log(
       `ipfsCid0ToNftID: ipfs: `,
       ipfs,
@@ -53,9 +53,9 @@ describe("metaNFT", function () {
     expect(LoopringAPI.nftAPI.ipfsCid0ToNftID(ipfs)).toBe(nftID);
   });
   it("ipfsNftIDToCid", () => {
-    const ipfs = "QmVYQaf5BP3y8Myr9m4z4FCZYx2v8NJmSHGzm2a2gqig9d";
+    const ipfs = "QmNuqdeWUJ9iEiw5qZfJ2pJ9onqAS45ZffvV8JQSUzp7DQ";
     const nftID =
-      "0x6b04cd991b972198cc63115c8abc3bf4ed73f07353c44271e940841b466a66f8";
+      "0x0880847b7587968f32ba6c741f9d797d9dc64971979922a80c4e590453b8dc2f";
 
     console.log(
       `ipfsCid0ToNftID: nftID: `,


### PR DESCRIPTION
This PR intends to fix EDDSA signature issues when minting on [loopring.io](https://loopring.io/) as discussed in [Issue 181](https://github.com/Loopring/loopring-wallet-feedback/issues/181)
Error code `104005`, `ERR_REST_EDDSA_INVALID_SIGNATURE` (see screenshot below)

Many users are hitting this issue regularly when trying to mint. The issue follows specific CIDs and would be solved by re-uploading a minimally modified `metadata.json`file to IPFS to get a different CID (adding an empty newline for example).
Through experimenting with the SDK and with other libraries, it's become clear that only the Loopring SDK was affected, and no community projects was experiencing this issue when minting problematic CIDs through [LooPyGen](https://github.com/sk33z3r/LooPyGen/) or [LoopMintSharp](https://github.com/fudgebucket27/LoopMintSharp).

The issue comes from the conversion of CIDv0 to hex-string NFT ID, when the hex-string NFT ID has one or more leading-zeros. 
For example: `QmNuqdeWUJ9iEiw5qZfJ2pJ9onqAS45ZffvV8JQSUzp7DQ` converts to `0x0880847b7587968f32ba6c741f9d797d9dc64971979922a80c4e590453b8dc2f`
The Loopring SDK function `LoopringAPI.nftAPI.ipfsCid0ToNftID()` would return `0x880847b7587968f32ba6c741f9d797d9dc64971979922a80c4e590453b8dc2f` (stripped leading `0`, only 63 nibbles), when the rest of the mint function expects a 64-nibble long hex-string. 
This would interfere with the NFT ID high and low input in the EDDSA hash and sign process.

This PR fixes the issue by padding the hex-string with `0` to guarantee a 64-nibble long hex-string is returned by `ipfsCid0ToNftID()`

![image](https://user-images.githubusercontent.com/2715455/164548354-6fc7cf67-43f8-44f1-a97c-4cd42b220e75.png)

