### PR TITLE
Patch Mock + Examples as accInfo.keySeed is empty string in API Response

### DIFF
--- a/docs/js_sdk/README.md
+++ b/docs/js_sdk/README.md
@@ -498,7 +498,7 @@ export async function signatureKeyPairMock(
     web3: _web3,
     address: accInfo.owner,
     keySeed:
-      accInfo.keySeed ??
+      accInfo.keySeed ||
       sdk.GlobalAPI.KEY_MESSAGE.replace(
         "${exchangeAddress}",
         LOOPRING_EXPORTED_ACCOUNT.exchangeAddress

--- a/src/tests/MockData.ts
+++ b/src/tests/MockData.ts
@@ -484,7 +484,7 @@ export async function signatureKeyPairMock(
     web3: _web3,
     address: accInfo.owner,
     keySeed:
-      accInfo.keySeed ??
+      accInfo.keySeed ||
       sdk.GlobalAPI.KEY_MESSAGE.replace(
         "${exchangeAddress}",
         LOOPRING_EXPORTED_ACCOUNT.exchangeAddress

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -498,7 +498,7 @@ export async function signatureKeyPairMock(
     web3: _web3,
     address: accInfo.owner,
     keySeed:
-      accInfo.keySeed ??
+      accInfo.keySeed ||
       sdk.GlobalAPI.KEY_MESSAGE.replace(
         "${exchangeAddress}",
         LOOPRING_EXPORTED_ACCOUNT.exchangeAddress


### PR DESCRIPTION
Thought this might help since the error I was getting took a while:

![CleanShot 2022-05-31 at 14 46 15@2x](https://user-images.githubusercontent.com/1503991/171272432-c15c66f9-61da-45b3-8296-c3c16433352e.png)

Error: `generateKeyPair personalSign error personalSign err before Validate:Error: HookedWalletSubprovider - validateMessage - message was not encoded as hex.`