### PR TITLE
getNextStorageId maxNext variable

### DIFF
--- a/src/defs/loopring_defs.ts
+++ b/src/defs/loopring_defs.ts
@@ -868,6 +868,7 @@ export interface UserFeeRateInfo {
 export interface GetNextStorageIdRequest {
   accountId: number;
   sellTokenId: number;
+  maxNext?: boolean;
 }
 
 /**


### PR DESCRIPTION
Would like to see this exposed. Not sure how a boolean gets translated to "0" or "1" in the api so might need some further testing: 

maxNext mention in API docs for this endpoint: https://docs.loopring.io/en/dex_apis/getNextStorageId.html