### PR TITLE
Fix crypto-js/sha256 import error

### DIFF
--- a/src/api/sign/sign_tools.ts
+++ b/src/api/sign/sign_tools.ts
@@ -1,4 +1,4 @@
-import sha256 from "crypto-js/sha256";
+import sha256 from "crypto-js/sha256.js";
 import * as abi from "ethereumjs-abi";
 import * as sigUtil from "eth-sig-util";
 


### PR DESCRIPTION
Per issue #68 this attempts to fix the import error: "BREAKING CHANGE: The request 'crypto-js/sha256' failed to resolve only because it was resolved as fully specified" by appending the file extension to the import statement.