### PR TITLE
fix: replace "main" and "module" with "exports" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "author": "Loopring Dev Team",
   "description": "Loopring SDK",
   "license": "SEE LICENSE IN LICENSE",
-  "main": "dist/index.js",
+  "exports": {
+    "import": "./dist/loopring-sdk.esm.js",
+    "require": "./dist/index.js"
+  },
   "typings": "dist/index.d.ts",
-  "module": "dist/loopring-sdk.esm.js",
   "files": [
     "dist",
     "!tests",


### PR DESCRIPTION
The package is shipped as an ESM package (because of the "type": "module" entry in package.json), but the entrypoint defined in "main" is a file importing one of 2 CommonJS versions of the library.

"module" entry is not actually understood by Node (never was).

Adding "exports" with 2 entries: "require" and "import" should inform Node that the ESM version of the package is available under the correct path, which is `./dist/loopring-sdk.esm.js`.