### PR TITLE
fix: add conditional types export to manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs",
     "import": "./dist/index.esm.js"
   },


### PR DESCRIPTION
This PR fixes types support of the library in projects that use modern values of `moduleResolution` TypeScript options.

## Rationale

Projects running TypeScript with moduleResolution set to `Node16`, `NodeNext` or `Bundler` upon finding the `package.json#exports` entry, will read the information in there to determine the location of the types and **discard any information in the top-level `types` entry**.


The way TS resolves the types is shown here:
https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution

The document above says that with the file extension substitution the types for the CJS version (`exports.require`) are searched for in `./dist/index.d.cts` and the types for the ESM (`exports.import`) are searched for in `./dist/index.esm.d.ts`, but none of these files exist. Instead, you have a single `./dist/index.d.ts` file.

To make TS look fot the types in there, you have to add the `"types": "./dist/index.d.ts"` entry as the first entry in `exports`.